### PR TITLE
return current version if bumping is not needed

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -50,6 +50,8 @@ runs:
       id: composeVersions
       run: |
         BUMPED_VERSION="${{steps.bumpSemver.outputs.new_tag}}"
+        CURRENT_VERSION="${{steps.bumpSemver.outputs.tag}}"
+        BUMPED_VERSION="${BUMPED_VERSION:-${CURRENT_VERSION}}"
         ASSEMBLY_VERSION=${BUMPED_VERSION%-*}
         COMMIT_HASH=${BUMPED_VERSION#*-}
         if [ $COMMIT_HASH == $BUMPED_VERSION ]
@@ -69,8 +71,9 @@ runs:
 
     - name: Print bumpSemver outputs
       run: |
-        echo "latest tag is ${{steps.bumpSemver.outputs.tag}}"
+        echo "current tag is ${{steps.bumpSemver.outputs.tag}}"
         echo "bumping ${{steps.bumpSemver.outputs.part}} level on ${{github.ref}} gives new tag ${{steps.bumpSemver.outputs.new_tag}}"
         echo "assembly version ${{steps.composeVersions.outputs.assemblyVersion}}"
         echo "product version ${{steps.composeVersions.outputs.productVersion}}"
+        echo "full version ${{steps.composeVersions.outputs.fullVersion}}"
       shell: bash


### PR DESCRIPTION
instead of not having  version at the end of the action